### PR TITLE
ci: build docker image for feature branches and releases only

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,9 +1,8 @@
 name: build docker image
 
 on:
-  push:
-#    branches:
-#      - master
+  - pull_request
+  - release
 
 permissions:
   contents: read


### PR DESCRIPTION
There are hundreds of actions triggering a workflow. Building the image in a feature branch and for a release is enough.