### PR TITLE
ci: clean the Docker images on GitHub

### DIFF
--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -15,4 +15,4 @@ jobs:
           package-name: errbot
           package-type: container
           # do not delete releases
-          ignore-versions: 'v\d+\.\d+\.\d+'
+          ignore-versions: '^\d+\.\d+\.\d+$'

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -1,0 +1,18 @@
+name: clean packages
+
+on:
+  schedule:
+    - cron: '30 1 * * 1'
+
+jobs:
+  clean_packages:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/delete-package-versions@v4
+        with:
+          package-name: errbot
+          package-type: container
+          # do not delete releases
+          ignore-versions: 'v\d+\.\d+\.\d+'


### PR DESCRIPTION
This is done once a week. Should be sufficient as we have one image per feature branch only (not per commit). Released versions are kept forever.