### PR TITLE
ci: allow `master` as scope in PRs

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -36,10 +36,10 @@ jobs:
             test
           # Configure which scopes are allowed.
           # deps - dependency updates
-          # main - for release-please (scope used for releases)
+          # master - for release-please (scope used for releases)
           scopes: |
             deps
-            main
+            master
           requireScope: false
           # ensure that the subject doesn't start with an uppercase character.
           subjectPattern: ^(?![A-Z]).+$


### PR DESCRIPTION
Release please uses the branch where the release is created as scope for the PR. This is an old project. The main branch is called `master`.