### PR TITLE
ci: do not create Python package on master pushes

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -4,8 +4,6 @@
 name: Python package
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
We use a PR to create a release. Thus the workflow runs on the PR and there is no need to run it as soon as the changes have been merged into the `master`.