### PR TITLE
ci: allow Renovate to run on a fork

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,4 @@
 {
   "extends": ["github>Hapag-Lloyd/Renovate-Global-Configuration"]
+  "forkProcessing": "enabled"
 }


### PR DESCRIPTION
Usually Renovate is disabled on forks. But as we actively develop in this repository we should get the current dependencies too.