### PR TITLE
ci: fix Renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,4 @@
 {
-  "extends": ["github>Hapag-Lloyd/Renovate-Global-Configuration"]
+  "extends": ["github>Hapag-Lloyd/Renovate-Global-Configuration"],
   "forkProcessing": "enabled"
 }


### PR DESCRIPTION
Json file was invalid. A `,` was missing.

Closes #44 