### PR TITLE
chore: include legacy-cgi to deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ deps = [
     "pygments-markdown-lexer==0.1.0.dev39",  # sytax coloring to debug md
     "dulwich==0.23.1",  # python implementation of git
     "deepmerge==2.0",
+    "legacy-cgi==2.6.3; python_version >= '3.12'",  # stopgap fix for webtest after cgi dropped from stdlib
 ]
 
 src_root = os.curdir


### PR DESCRIPTION
<!--- yamllint disable rule:single-title/single-h1 -->

# Description

webtest is used to validate incoming webhooks in the production Webserver().

Via webtest and webob, we have a transitive dependency on cgi.
As of python 3.13 [cgi has been dropped from stdlib](https://docs.python.org/3/deprecations/pending-removal-in-3.13.html).

The recommended stopgap is to add an explicit dependency on legacy-cgi,
long term webob should be replaced with WSGI or ASGI

See: https://github.com/errbotio/errbot/pull/1729