### PR TITLE
revert: "chore: include legacy-cgi to deps"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ deps = [
     "pygments-markdown-lexer==0.1.0.dev39",  # sytax coloring to debug md
     "dulwich==0.23.1",  # python implementation of git
     "deepmerge==2.0",
-    "legacy-cgi==2.6.3; python_version >= '3.12'",  # stopgap fix for webtest after cgi dropped from stdlib
 ]
 
 src_root = os.curdir


### PR DESCRIPTION
Reverts Hapag-Lloyd/errbot#101 as this is not working as expected for Python 3.13